### PR TITLE
Fix bash command for installing the project dependencies using npm in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cd imaginify
 Install the project dependencies using npm:
 
 ```bash
-npm run dev
+npm install
 ```
 
 **Set Up Environment Variables**


### PR DESCRIPTION
The correct bash command for installing the project dependencies using npm is "npm install" not "npm run dev"